### PR TITLE
[Chore] Update contract addresses for testnet

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,10 +148,10 @@ func getSupportedTokens(network string) map[string]bool {
 	case optimism.TestnetNetwork: // Goerli - 420
 		return map[string]bool{
 			"0x4200000000000000000000000000000000000042": true, // OP
-			"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1": true, // DAI
-			"0x2E5ED97596a8368EB9E44B1f3F25B2E813845303": true, // SNX
+			"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": true, // DAI
+			"0x2e5ed97596a8368eb9e44b1f3f25b2e813845303": true, // SNX
 			"0x7f5c764cbc14f9669b88837ca1490cca17c31607": true, // USDT - obsolete
-			"0xe0a592353e81a94Db6E3226fD4A99F881751776a": true, // WBTC
+			"0xe0a592353e81a94db6e3226fd4a99f881751776a": true, // WBTC
 			// "": true, // USDC
 		}
 	default:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -150,8 +150,9 @@ func getSupportedTokens(network string) map[string]bool {
 			"0x4200000000000000000000000000000000000042": true, // OP
 			"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1": true, // DAI
 			"0x2E5ED97596a8368EB9E44B1f3F25B2E813845303": true, // SNX
-			"0x7f5c764cbc14f9669b88837ca1490cca17c31607": true, // USDT
+			"0x7f5c764cbc14f9669b88837ca1490cca17c31607": true, // USDT - obsolete
 			"0xe0a592353e81a94Db6E3226fD4A99F881751776a": true, // WBTC
+			// "": true, // USDC
 		}
 	default:
 		return map[string]bool{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -145,13 +145,13 @@ func getSupportedTokens(network string) map[string]bool {
 			"0x68f180fcce6836688e9084f035309e29bf0a2095": true, // WBTC
 			//"0x7F5c764cBc14f9669B88837ca1490cCa17c31607": true, // USDC
 		}
-	case optimism.TestnetNetwork:
+	case optimism.TestnetNetwork: // Goerli - 420
 		return map[string]bool{
 			"0x4200000000000000000000000000000000000042": true, // OP
-			"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": true, // DAI
-			"0x0064a673267696049938aa47595dd0b3c2e705a1": true, // SNX
+			"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1": true, // DAI
+			"0x2E5ED97596a8368EB9E44B1f3F25B2E813845303": true, // SNX
 			"0x7f5c764cbc14f9669b88837ca1490cca17c31607": true, // USDT
-			"0x2382a8f65b9120e554d1836a504808ac864e169d": true, // WBTC
+			"0xe0a592353e81a94Db6E3226fD4A99F881751776a": true, // WBTC
 		}
 	default:
 		return map[string]bool{


### PR DESCRIPTION
Fixes # .

### Motivation
Now that Goerli is the default testnet, we need to update contract address to be the addresses on Goerli listed [here](https://github.com/ethereum-optimism/ethereum-optimism.github.io/blob/master/optimism.tokenlist.json)

### Followup
Update addresses for USDT and USDC separately once they become available

### Open questions

