### PR TITLE
Remove SNX from supported tokens

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -141,7 +141,6 @@ func getSupportedTokens(network string) map[string]bool {
 		return map[string]bool{
 			"0x4200000000000000000000000000000000000042": true, // OP
 			"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": true, // DAI
-			"0x8700daec35af8ff88c16bdf0418774cb3d7599b4": true, // SNX
 			"0x94b008aa00579c1307b0ef2c499ad98a8ce58e58": true, // USDT
 			"0x68f180fcce6836688e9084f035309e29bf0a2095": true, // WBTC
 			"0x7f5c764cbc14f9669b88837ca1490cca17c31607": true, // USDC
@@ -150,7 +149,6 @@ func getSupportedTokens(network string) map[string]bool {
 		return map[string]bool{
 			"0x4200000000000000000000000000000000000042": true, // OP
 			"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": true, // DAI
-			"0x2e5ed97596a8368eb9e44b1f3f25b2e813845303": true, // SNX
 			"0x853eb4ba5d0ba2b77a0a5329fd2110d5ce149ece": true, // USDT
 			"0xe0a592353e81a94db6e3226fd4a99f881751776a": true, // WBTC
 			"0x7e07e15d2a87a24492740d16f5bdf58c16db0c4e": true, // USDC


### PR DESCRIPTION
SNX uses a custom bridge with non-standard semantics and is not compatible with Rosetta