### PR TITLE
Fix block_response fixture for the bedrock test

### DIFF
--- a/optimism/client_bedrock_test.go
+++ b/optimism/client_bedrock_test.go
@@ -9,10 +9,10 @@ import (
 	mocks "github.com/coinbase/rosetta-ethereum/mocks/optimism"
 	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum-optimism/optimism/l2geth/common"
-	"github.com/ethereum-optimism/optimism/l2geth/core/types"
 	"github.com/ethereum-optimism/optimism/l2geth/eth"
 	"github.com/ethereum-optimism/optimism/l2geth/params"
 	"github.com/ethereum-optimism/optimism/l2geth/rpc"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/sync/semaphore"
@@ -43,6 +43,7 @@ func TestBedrock_BlockCurrent(t *testing.T) {
 		tc:              testBedrockTraceConfig,
 		p:               params.GoerliChainConfig,
 		traceSemaphore:  semaphore.NewWeighted(100),
+		filterTokens:    false,
 	}
 
 	ctx := context.Background()
@@ -148,7 +149,6 @@ func mockGetTransactionReceipt(ctx context.Context, t *testing.T, mockJSONRPC *m
 				file, err := ioutil.ReadFile(txFileData[i])
 				assert.NoError(t, err)
 
-				// TODO: we should use op-geth types here because l2geth Receipts do not contain a Type field.
 				receipt := new(types.Receipt)
 				assert.NoError(t, receipt.UnmarshalJSON(file))
 				*(r[0].Result.(**types.Receipt)) = receipt

--- a/optimism/testdata/goerli_bedrock_block_response_5003318.json
+++ b/optimism/testdata/goerli_bedrock_block_response_5003318.json
@@ -170,6 +170,141 @@
                 "decimals": 18
               }
             }
+          },
+          {
+            "operation_identifier": {
+              "index": 4
+            },
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0xE60CeAd5FCD752B6694f90a16af7a46e5b6Df817"
+            },
+            "amount": {
+              "value": "-100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 5
+            },
+            "related_operations": [
+              {
+                "index": 4
+              }
+            ],
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x6E532F86CD5721A976f15560Aa0683521cFaB7e7"
+            },
+            "amount": {
+              "value": "100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 6
+            },
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x6E532F86CD5721A976f15560Aa0683521cFaB7e7"
+            },
+            "amount": {
+              "value": "-100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 7
+            },
+            "related_operations": [
+              {
+                "index": 6
+              }
+            ],
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x25c53f77e4f6FC85CbA2a892Ac62A44C770389cC"
+            },
+            "amount": {
+              "value": "100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 8
+            },
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x25c53f77e4f6FC85CbA2a892Ac62A44C770389cC"
+            },
+            "amount": {
+              "value": "-100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 9
+            },
+            "related_operations": [
+              {
+                "index": 8
+              }
+            ],
+            "type": "ERC20_TRANSFER",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x794C23BB0a718F4a79eE96531d40C54A67f7f037"
+            },
+            "amount": {
+              "value": "100",
+              "currency": {
+                "symbol": "LINK",
+                "decimals": 18,
+                "metadata": {
+                  "contractAddress": "0xdc2CC710e42857672E7907CF474a69B63B93089f"
+                }
+              }
+            }
           }
         ],
         "metadata": {


### PR DESCRIPTION
The block response should have included ERC20 transfers.
Also use upstream go-ethereum types for mocks rather than l2geth so the Client can access the Receipt type.