### PR TITLE
Use "CALL" op type for deposits

### DIFF
--- a/optimism/client_blocks_bedrock_ops.go
+++ b/optimism/client_blocks_bedrock_ops.go
@@ -37,7 +37,8 @@ func MintOps(tx *bedrockTransaction, startIndex int) []*RosettaTypes.Operation {
 	}
 
 	opIndex := int64(startIndex)
-	opType := MintOpType
+	// "CALL" is used here to remain backwards-compatible with pre-bedrock Rosetta behavior
+	opType := CallOpType
 	opStatus := SuccessStatus
 	fromAddress := MustChecksum(tx.From.String())
 	amount := Amount(tx.Transaction.GetValue(), Currency)

--- a/optimism/client_blocks_bedrock_ops_test.go
+++ b/optimism/client_blocks_bedrock_ops_test.go
@@ -125,7 +125,7 @@ func (testSuite *BedrockOpsTestSuite) TestValidMint() {
 			OperationIdentifier: &RosettaTypes.OperationIdentifier{
 				Index: int64(index),
 			},
-			Type:   MintOpType,
+			Type:   CallOpType,
 			Status: RosettaTypes.String(SuccessStatus),
 			Account: &RosettaTypes.AccountIdentifier{
 				Address: from.String(),

--- a/optimism/testdata/goerli_bedrock_block_response_5003318.json
+++ b/optimism/testdata/goerli_bedrock_block_response_5003318.json
@@ -19,7 +19,7 @@
             "operation_identifier": {
               "index": 0
             },
-            "type": "MINT",
+            "type": "CALL",
             "status": "SUCCESS",
             "account": {
               "address": "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001"

--- a/optimism/types.go
+++ b/optimism/types.go
@@ -28,8 +28,6 @@ import (
 const (
 	// MintOpType is a [RosettaTypes.Operation] type for an Optimism Deposit or "mint" transaction.
 	MintOpType = "MINT"
-	// BurnOpType is a [RosettaTypes.Operation] type for an Optimism Withdrawal or "burn" transaction.
-	BurnOpType = "BURN"
 	// An erroneous STOP Type not defined in rosetta-geth-sdk
 	StopOpType = "STOP"
 )


### PR DESCRIPTION
This is done to retain backwards-compatibility with the old rosetta behavior