### PR TITLE
ctor: Fee estimation changes

### DIFF
--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -764,11 +764,15 @@ func (s *ConstructionAPIService) calculateFeeCaps(ctx context.Context, gasTipCap
 			// between the safe and unsafe chain shows an increase of approximately 76%. For extra safety, we set the gas price to be twice the base
 			// fee to ensure transaction inclusion.
 			// The base fee increases at most 12.5% per block. So even assuming when the network is half-congested (at a ~6% increase),
-			// a 100% base fee tip won't be effective when the base fee is low. Thus, to ensure transaction inclusion when the base fee is low and
-			// congestion is ramping up, we also add a fixed 1000 wei tip to the gas price.
+			// a 100% base fee won't be effective when the base fee is low. Thus, to ensure transaction inclusion when the base fee is low and
+			// congestion is ramping up, the gas fee cap is further increased by 2000 wei.
 			// Ideally, Rosetta should lookup base fee info from the unsafe chain for more accurate gas pricing.
-			gasTipCap = new(big.Int).Add(big.NewInt(1000), baseFee)
-			gasFeeCap := new(big.Int).Add(baseFee, gasTipCap)
+			lowBaseFeeAdjustment := big.NewInt(2000)
+			baseFeeIncreaseMultiplier := big.NewInt(4)
+			gasTipCap = big.NewInt(10)
+			gasFeeCap := new(big.Int).Mul(baseFee, baseFeeIncreaseMultiplier)
+			gasFeeCap.Add(gasFeeCap, lowBaseFeeAdjustment)
+			gasFeeCap.Add(gasFeeCap, gasTipCap)
 			return gasTipCap, gasFeeCap, nil
 		}
 	}

--- a/services/construction_service_test.go
+++ b/services/construction_service_test.go
@@ -48,8 +48,8 @@ var (
 	transferValue         = uint64(20211004)
 	transferBaseFee       = uint64(200)
 	transferGasPrice      = uint64(5000000000)
-	transferGasTipCap     = transferBaseFee + 1000
-	transferGasFeeCap     = uint64(transferBaseFee + transferGasTipCap)
+	transferGasTipCap     = uint64(10)
+	transferGasFeeCap     = uint64(4*transferBaseFee + transferGasTipCap + 2000)
 	transferGasLimit      = uint64(21000)
 	transferGasLimitERC20 = uint64(65000)
 	transferNonce         = uint64(67)
@@ -440,7 +440,7 @@ func TestMetadata(t *testing.T) {
 				},
 				SuggestedFee: []*types.Amount{
 					{
-						Value:    fmt.Sprintf("%d", (transferBaseFee+transferGasTipCap)*transferGasLimit),
+						Value:    fmt.Sprintf("%d", transferGasFeeCap*transferGasLimit),
 						Currency: optimism.Currency,
 					},
 				},
@@ -522,7 +522,7 @@ func TestMetadata(t *testing.T) {
 				},
 				SuggestedFee: []*types.Amount{
 					{
-						Value:    fmt.Sprintf("%d", (transferBaseFee+transferGasTipCap)*transferGasLimit),
+						Value:    fmt.Sprintf("%d", transferGasFeeCap*transferGasLimit),
 						Currency: optimism.Currency,
 					},
 				},
@@ -613,7 +613,7 @@ func TestMetadata(t *testing.T) {
 				},
 				SuggestedFee: []*types.Amount{
 					{
-						Value:    fmt.Sprintf("%d", (transferBaseFee+transferGasTipCap)*transferGasLimitERC20),
+						Value:    fmt.Sprintf("%d", transferGasFeeCap*transferGasLimitERC20),
 						Currency: optimism.Currency,
 					},
 				},


### PR DESCRIPTION
The fee adjustment due to an out of date base fee is increased to reduce the changes of stuck transactions in the mempool.
The gas tip cap is reduced, while increasing the gas fee cap. This reduces the cost of replacing transactions in the mempool.