### PR TITLE
Add sepolia network

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -177,6 +177,8 @@ func getBedrockBlock(network string) *big.Int {
 		return big.NewInt(4061224)
 	case optimism.MainnetNetwork:
 		return big.NewInt(105235063)
+	case optimism.SepoliaNetwork:
+		return big.NewInt(0)
 	default:
 		return big.NewInt(0)
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -47,6 +47,9 @@ const (
 	// Goerli is the Ethereum Görli testnet.
 	Goerli string = "GOERLI"
 
+	// Sepolia is the Ethereum Sepolia testnet.
+	Sepolia string = "SEPOLIA"
+
 	// Testnet defaults to `Ropsten` for backwards compatibility (even though we don't have a ropsten network on Optimism).
 	Testnet string = "TESTNET"
 
@@ -182,6 +185,16 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = optimism.GoerliGenesisBlockIdentifier
 		config.Params = params.GoerliChainConfig
 		config.GethArguments = optimism.GoerliGethArguments
+	case Sepolia:
+		// TODO: Testnet should eventually be using Sepolia configs
+		config.Network = &types.NetworkIdentifier{
+			Blockchain: optimism.Blockchain,
+			Network:    optimism.SepoliaNetwork,
+		}
+		config.GenesisBlockIdentifier = optimism.SepoliaGenesisBlockIdentifier
+		config.Params = params.TestnetChainConfig
+		config.Params.ChainID = big.NewInt(11155420) // TODO: temporary fix without param update
+		config.GethArguments = optimism.TestnetGethArguments
 	case "":
 		return nil, errors.New("NETWORK must be populated")
 	default:

--- a/optimism/types.go
+++ b/optimism/types.go
@@ -92,6 +92,9 @@ const (
 	// in TestnetNetworkIdentifier.
 	TestnetNetwork string = "Testnet"
 
+	// SepoliaNetwork is the value of the sepolia network.
+	SepoliaNetwork string = "Sepolia"
+
 	// GoerliNetwork is the value of the network
 	// in GoerliNetworkNetworkIdentifier.
 	GoerliNetwork string = "Goerli"
@@ -226,6 +229,11 @@ var (
 	// of the Goerli genesis block.
 	GoerliGenesisBlockIdentifier = &types.BlockIdentifier{
 		Hash:  "0xb643d8aa991fb19f47b9178818886afb4eb54589eb500967beb444ea64f9761b",
+		Index: GenesisBlockIndex,
+	}
+
+	SepoliaGenesisBlockIdentifier = &types.BlockIdentifier{
+		Hash:  "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d",
 		Index: GenesisBlockIndex,
 	}
 


### PR DESCRIPTION
Adds a new `Sepolia` network for rosetta requests. The rosetta server should be configured with NETWORK=SEPOLIA to support this.